### PR TITLE
fix filename display ec2

### DIFF
--- a/ecSource/include/ecSynth.h
+++ b/ecSource/include/ecSynth.h
@@ -266,7 +266,11 @@ class ecSynth : public al::SynthVoice {
     float sf_mod_val = ECParameters[consts::SOUND_FILE]->getModParam(ECModParameters[consts::SOUND_FILE]->getWidthParam());
     sf_mod_val = sf_mod_val - (int)sf_mod_val > 0.5 ? ceil(sf_mod_val) : floor(sf_mod_val);
     std::string filename = soundClipFileName[sf_mod_val - 1];
+#ifdef _WIN32
+    filename = filename.substr(filename.find_last_of("\\") + 1);
+#else
     filename = filename.substr(filename.find_last_of("/") + 1);
+#endif
     return filename;
   }
 

--- a/ecSource/scripts/packageWindows.sh
+++ b/ecSource/scripts/packageWindows.sh
@@ -13,8 +13,6 @@ mkdir -p "../deployment/Windows/"
 cp -r bin ../deployment/Windows
 cd ../deployment/Windows
 cp ../../docs/EmissionControl2-Manual.pdf ./bin/
-rm ./bin/EmissionControl2.ilk
-rm ./bin/EmissionControl2.pdb
 cp ../../LICENSE ./bin/
 mv bin EmissionControl2
 echo "EmissionControl2 moved to: $(pwd)"


### PR DESCRIPTION
now only display the sound file name, rather than the path on windows